### PR TITLE
feat: added support for entity_types and game_events tags

### DIFF
--- a/mod-sourcer/collect_mod_tags.py
+++ b/mod-sourcer/collect_mod_tags.py
@@ -10,7 +10,7 @@ from datastructures import *
 
 build_dir = Path('build')
 
-TAG_PATTERN = re.compile("^data/c/tags/(items|blocks|fluids)/(.*).json$")
+TAG_PATTERN = re.compile("^data/c/tags/(items|blocks|fluids|entity_types|game_events)/(.*).json$")
 
 
 def load_tags(mod_jar: ZipFile, source: TagSource, tags: TagContainer):

--- a/mod-sourcer/datastructures.py
+++ b/mod-sourcer/datastructures.py
@@ -103,6 +103,8 @@ class TagContainer:
     items: Dict[str, Tag]
     blocks: Dict[str, Tag]
     fluids: Dict[str, Tag]
+    entity_types: Dict[str, Tag]
+    game_events: Dict[str, Tag]
 
     def __init__(self) -> None:
         super().__init__()
@@ -110,6 +112,8 @@ class TagContainer:
         self.items = {}
         self.blocks = {}
         self.fluids = {}
+        self.entity_types = {}
+        self.game_events = {}
 
     def add_tag(self, tag_type: str, source: TagSource, tag_id: str, tag_json: Dict):
         self.sources.add(source)
@@ -126,7 +130,9 @@ class TagContainer:
             'sources': {source.mod_id: source.to_json() for source in self.sources},
             'items': [x.to_json() for x in self.items.values()],
             'blocks': [x.to_json() for x in self.blocks.values()],
-            'fluids': [x.to_json() for x in self.fluids.values()]
+            'fluids': [x.to_json() for x in self.fluids.values()],
+            'entity_types': [x.to_json() for x in self.entity_types.values()],
+            'game_events': [x.to_json() for x in self.game_events.values()]
         }
 
     @classmethod
@@ -136,10 +142,14 @@ class TagContainer:
         sources = {s.mod_id: s for s in tags.sources}
 
         def load_tags(key):
+            if key not in json:
+                json[key] = []
             tag_list = [Tag.from_json(x, sources) for x in json[key]]
             return {t.id: t for t in tag_list}
 
         tags.items = load_tags('items')
         tags.blocks = load_tags('blocks')
         tags.fluids = load_tags('fluids')
+        tags.entity_types = load_tags('entity_types')
+        tags.game_events = load_tags('game_events')
         return tags

--- a/mod-sourcer/to_mediawiki.py
+++ b/mod-sourcer/to_mediawiki.py
@@ -41,6 +41,16 @@ with open('tags.txt', 'wt') as out:
     generate_page(root['sources'], root['fluids'], out)
 
     print(file=out)
+    print('===== Entity Types Tags =====', file=out)
+    print(file=out)
+    generate_page(root['sources'], root['entity_types'], out)
+
+    print(file=out)
+    print('===== Game Events Tags =====', file=out)
+    print(file=out)
+    generate_page(root['sources'], root['game_events'], out)
+
+    print(file=out)
     print('===== Sources =====', file=out)
     print(file=out)
     print("^ Mod ID ^ Name ^ Version ^ URL ^", file=out)


### PR DESCRIPTION
Inlcuded support for tags in `entity_tags` and `game_events` (1.17) folder.

Example result of the process on the mod [`Earth2Java-1.7.0+21w17a.jar`](https://www.curseforge.com/minecraft/mc-mods/earth2java-fabric/files/3294829)

```txt
===== Item Tags =====

^ Tag ID ^ Contained IDs ^ Defined by ^
| c:beds| earthtojavamobs:rainbow_bed| earthtojavamobs |
| c:carpets| earthtojavamobs:rainbow_carpet| earthtojavamobs |
| c:flowers| #c:small_flowers| earthtojavamobs |
| :::| #c:tall_flowers| earthtojavamobs |
| c:small_flowers| earthtojavamobs:buttercup| earthtojavamobs |
| :::| earthtojavamobs:pink_daisy| earthtojavamobs |
| c:wool| earthtojavamobs:rainbow_wool| earthtojavamobs |

===== Block Tags =====

^ Tag ID ^ Contained IDs ^ Defined by ^
| c:beds| earthtojavamobs:rainbow_bed| earthtojavamobs |
| c:carpets| earthtojavamobs:rainbow_carpet| earthtojavamobs |
| c:flower_pots| earthtojavamobs:potted_buttercup| earthtojavamobs |
| :::| earthtojavamobs:potted_pink_daisy| earthtojavamobs |
| c:flowers| #c:small_flowers| earthtojavamobs |
| :::| #c:tall_flowers| earthtojavamobs |
| c:small_flowers| earthtojavamobs:buttercup| earthtojavamobs |
| :::| earthtojavamobs:pink_daisy| earthtojavamobs |
| c:wool| earthtojavamobs:rainbow_wool| earthtojavamobs |

===== Fluid Tags =====

^ Tag ID ^ Contained IDs ^ Defined by ^
| c:mud| earthtojavamobs:mud_fluid| earthtojavamobs |
| :::| earthtojavamobs:mud_fluid_flowing| earthtojavamobs |

===== Entity Types Tags =====

^ Tag ID ^ Contained IDs ^ Defined by ^
| c:raiders| earthtojavamobs:viler_witch| earthtojavamobs |
| c:skeletons| earthtojavamobs:skeleton_wolf| earthtojavamobs |

===== Game Events Tags =====

^ Tag ID ^ Contained IDs ^ Defined by ^

===== Sources =====

^ Mod ID ^ Name ^ Version ^ URL ^
...
```